### PR TITLE
Update gps_information.md

### DIFF
--- a/gps_control_command/gps_information.md
+++ b/gps_control_command/gps_information.md
@@ -18,15 +18,16 @@ Acquires and sets the GPS information to the camera.
 |:--|:--|:--|
 | Latitude | float64 | Latitude. |
 | Longitude | float64 | Longitude. |
-| Altitude | float64 | Altitude.<br>-9999 -- 9999 |
-| Year | sint16 | 1582 -- 9999 |
-| Month | sint8 | 1 -- 12 |
-| Day | sint8 | 1 -- 31 |
-| Hours | sint8 | 0 -- 23 |
-| Minutes | sint8 | 0 -- 59 |
-| Seconds | sint8 | 0 -- 59 |
-| Time Zone | utf8s | + (-) hh:mm (Fixed to 6 digits) |
-| Datum | sint8 | 0（WGS84）|
+| Altitude | float64 | Altitude.<br>`-9999` -- `9999` (TBC) |
+| Year | sint16 | `1582` -- `9999` (TBC), **LITTLE ENDIAN** |
+| Month | sint8 | `1` -- `12` |
+| Day | sint8 | `1` -- `31` |
+| Hours | sint8 | `0` -- `23` |
+| Minutes | sint8 | `0` -- `59` |
+| Seconds | sint8 | `0` -- `59` |
+| Datum | sint8 | Always `0`（WGS84）|
+
+Everything except the year field is in BIG_ENDIAN order. The timestamp is the time the location was acquired, not the current wall clock time. It is always expressed at UTC.
 
 ### Properties
 


### PR DESCRIPTION
Hi there! I spent some time reverse engineering how to sync the GPS location with the camera. I tried using the documentation you provided, but it is partly incorrect. The correct format seems to be omitting the timezone info (all timestamps are in UTC), and for whatever reason the year is in little endian order.

I cross-checked with the values returned from the camera after syncing using the Ricoh's app, and that lines up. Yes, I know how weird that sounds 🙃